### PR TITLE
Add ? to Question and drop additional whitespace

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,9 +25,6 @@
     />
 
     <style>
-      a {
-        display: inline-block;
-      }
       h1,
       h2,
       h3 {
@@ -364,7 +361,7 @@
     </div>
     <div class="w-full bg-red-600 p-8 text-white text-center">
       In the meantime, why don't you check out the
-      <a class="font-semibold underline"
+      <a class="font-semibold underline inline-block"
         href="https://remoteruby.transistor.fm"
         target="_blank"
       >

--- a/index.html
+++ b/index.html
@@ -25,6 +25,9 @@
     />
 
     <style>
+      a {
+        display: inline-block;
+      }
       h1,
       h2,
       h3 {
@@ -361,14 +364,13 @@
     </div>
     <div class="w-full bg-red-600 p-8 text-white text-center">
       In the meantime, why don't you check out the
-      <a
-        class="font-semibold underline"
+      <a class="font-semibold underline"
         href="https://remoteruby.transistor.fm"
         target="_blank"
       >
         Remote Ruby
       </a>
-      podcast.
+      podcast?
     </div>
   </body>
 </html>


### PR DESCRIPTION
Problem:
Noticed at the bottom of the page there is some additional whitespace after the link and the question doesn't end in a question mark.

Solution:
Added a question mark and added a style for displaying anchors as inline-block which removes whitespaces from underlines.